### PR TITLE
Make temporary workaround in todoapp to build iOS with M1 and Intel CPU's

### DIFF
--- a/examples/todoapp/buildSrc/buildSrc/src/main/kotlin/Deps.kt
+++ b/examples/todoapp/buildSrc/buildSrc/src/main/kotlin/Deps.kt
@@ -12,7 +12,11 @@ fun initDeps(project: Project) {
 object Deps {
     object JetBrains {
         object Kotlin {
-            private val VERSION get() = properties["kotlin.version"]
+            //todo remove, when updated to new Compose with support Kotlin 1.6.20 or newer
+            private val XCODE_WORKAROUND_KOTLIN_VERSION = "1.6.20"
+            private val workaroundIsBuildWithXcode = System.getenv("XCODE_VERSION_ACTUAL") != null
+
+            private val VERSION get() = if (workaroundIsBuildWithXcode) XCODE_WORKAROUND_KOTLIN_VERSION else properties["kotlin.version"]
             val gradlePlugin get() = "org.jetbrains.kotlin:kotlin-gradle-plugin:$VERSION"
             val testCommon get() = "org.jetbrains.kotlin:kotlin-test-common:$VERSION"
             val testJunit get() = "org.jetbrains.kotlin:kotlin-test-junit:$VERSION"

--- a/examples/todoapp/buildSrc/buildSrc/src/main/kotlin/Deps.kt
+++ b/examples/todoapp/buildSrc/buildSrc/src/main/kotlin/Deps.kt
@@ -12,11 +12,7 @@ fun initDeps(project: Project) {
 object Deps {
     object JetBrains {
         object Kotlin {
-            //todo remove, when updated to new Compose with support Kotlin 1.6.20 or newer
-            private val XCODE_WORKAROUND_KOTLIN_VERSION = "1.6.20"
-            private val workaroundIsBuildWithXcode = System.getenv("XCODE_VERSION_ACTUAL") != null
-
-            private val VERSION get() = if (workaroundIsBuildWithXcode) XCODE_WORKAROUND_KOTLIN_VERSION else properties["kotlin.version"]
+            private val VERSION get() = properties["kotlin.version"]
             val gradlePlugin get() = "org.jetbrains.kotlin:kotlin-gradle-plugin:$VERSION"
             val testCommon get() = "org.jetbrains.kotlin:kotlin-test-common:$VERSION"
             val testJunit get() = "org.jetbrains.kotlin:kotlin-test-junit:$VERSION"

--- a/examples/todoapp/buildSrc/buildSrc/src/main/kotlin/Env.kt
+++ b/examples/todoapp/buildSrc/buildSrc/src/main/kotlin/Env.kt
@@ -1,6 +1,0 @@
-
-fun isIphoneSimulatorBuild(): Boolean =
-    System.getenv("NATIVE_ARCH") == "arm64" && System.getenv("SDK_NAME")?.startsWith("iphonesimulator") == true
-
-fun isIphoneOsBuild(): Boolean =
-    System.getenv("SDK_NAME")?.startsWith("iphoneos") == true

--- a/examples/todoapp/buildSrc/gradle.properties
+++ b/examples/todoapp/buildSrc/gradle.properties
@@ -1,3 +1,4 @@
 # TODO can we get rid of duplication with root gradle.properties?
+#todo remove -Pkotlin.version=1.6.20 from Xcode project, when stable version on Compose with Koltin 1.6.20 or later released
 kotlin.version=1.6.10
 compose.version=1.1.0

--- a/examples/todoapp/common/database/build.gradle.kts
+++ b/examples/todoapp/common/database/build.gradle.kts
@@ -13,16 +13,6 @@ sqldelight {
 }
 
 kotlin {
-    val iosTarget: (String, KotlinNativeTarget.() -> Unit) -> KotlinNativeTarget =
-        when {
-            isIphoneSimulatorBuild() -> ::iosSimulatorArm64
-            isIphoneOsBuild() -> ::iosArm64
-            else -> ::iosX64
-        }
-
-    iosTarget("ios") {
-    }
-
     sourceSets {
         commonMain {
             dependencies {

--- a/examples/todoapp/common/database/build.gradle.kts
+++ b/examples/todoapp/common/database/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-
 plugins {
     id("multiplatform-setup")
     id("android-setup")

--- a/examples/todoapp/common/edit/build.gradle.kts
+++ b/examples/todoapp/common/edit/build.gradle.kts
@@ -6,16 +6,6 @@ plugins {
 }
 
 kotlin {
-    val iosTarget: (String, KotlinNativeTarget.() -> Unit) -> KotlinNativeTarget =
-        when {
-            isIphoneSimulatorBuild() -> ::iosSimulatorArm64
-            isIphoneOsBuild() -> ::iosArm64
-            else -> ::iosX64
-        }
-
-    iosTarget("ios") {
-    }
-
     sourceSets {
         named("commonMain") {
             dependencies {

--- a/examples/todoapp/common/edit/build.gradle.kts
+++ b/examples/todoapp/common/edit/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-
 plugins {
     id("multiplatform-setup")
     id("android-setup")

--- a/examples/todoapp/common/main/build.gradle.kts
+++ b/examples/todoapp/common/main/build.gradle.kts
@@ -6,16 +6,6 @@ plugins {
 }
 
 kotlin {
-    val iosTarget: (String, KotlinNativeTarget.() -> Unit) -> KotlinNativeTarget =
-        when {
-            isIphoneSimulatorBuild() -> ::iosSimulatorArm64
-            isIphoneOsBuild() -> ::iosArm64
-            else -> ::iosX64
-        }
-
-    iosTarget("ios") {
-    }
-
     sourceSets {
         named("commonMain") {
             dependencies {
@@ -38,6 +28,9 @@ kotlin {
     }
 
     targets.getByName<KotlinNativeTarget>("iosX64").compilations.forEach {
+        it.kotlinOptions.freeCompilerArgs += arrayOf("-linker-options", "-lsqlite3")
+    }
+    targets.getByName<KotlinNativeTarget>("iosArm64").compilations.forEach {
         it.kotlinOptions.freeCompilerArgs += arrayOf("-linker-options", "-lsqlite3")
     }
 }

--- a/examples/todoapp/common/main/build.gradle.kts
+++ b/examples/todoapp/common/main/build.gradle.kts
@@ -26,11 +26,4 @@ kotlin {
             }
         }
     }
-
-    targets.getByName<KotlinNativeTarget>("iosX64").compilations.forEach {
-        it.kotlinOptions.freeCompilerArgs += arrayOf("-linker-options", "-lsqlite3")
-    }
-    targets.getByName<KotlinNativeTarget>("iosArm64").compilations.forEach {
-        it.kotlinOptions.freeCompilerArgs += arrayOf("-linker-options", "-lsqlite3")
-    }
 }

--- a/examples/todoapp/common/root/build.gradle.kts
+++ b/examples/todoapp/common/root/build.gradle.kts
@@ -10,7 +10,7 @@ kotlin {
     ios {
         binaries {
             framework {
-                baseName = "Todo"
+                baseName = "KotlinCommon"
                 linkerOpts.add("-lsqlite3")
                 export(project(":common:database"))
                 export(project(":common:main"))

--- a/examples/todoapp/common/root/build.gradle.kts
+++ b/examples/todoapp/common/root/build.gradle.kts
@@ -7,14 +7,7 @@ plugins {
 }
 
 kotlin {
-    val iosTarget: (String, KotlinNativeTarget.() -> Unit) -> KotlinNativeTarget =
-        when {
-            isIphoneSimulatorBuild() -> ::iosSimulatorArm64
-            isIphoneOsBuild() -> ::iosArm64
-            else -> ::iosX64
-        }
-
-    iosTarget("ios") {
+    ios {
         binaries {
             framework {
                 baseName = "Todo"

--- a/examples/todoapp/common/utils/build.gradle.kts
+++ b/examples/todoapp/common/utils/build.gradle.kts
@@ -6,12 +6,6 @@ plugins {
 }
 
 kotlin {
-    fun isIphoneSimulatorBuild(): Boolean =
-        System.getenv("NATIVE_ARCH") == "arm64" && System.getenv("SDK_NAME")?.startsWith("iphonesimulator") == true
-
-    fun isIphoneOsBuild(): Boolean =
-        System.getenv("SDK_NAME")?.startsWith("iphoneos") == true
-
     val iosTarget: (String, KotlinNativeTarget.() -> Unit) -> KotlinNativeTarget =
         when {
             isIphoneSimulatorBuild() -> ::iosSimulatorArm64

--- a/examples/todoapp/common/utils/build.gradle.kts
+++ b/examples/todoapp/common/utils/build.gradle.kts
@@ -6,16 +6,6 @@ plugins {
 }
 
 kotlin {
-    val iosTarget: (String, KotlinNativeTarget.() -> Unit) -> KotlinNativeTarget =
-        when {
-            isIphoneSimulatorBuild() -> ::iosSimulatorArm64
-            isIphoneOsBuild() -> ::iosArm64
-            else -> ::iosX64
-        }
-
-    iosTarget("ios") {
-    }
-
     sourceSets {
         named("commonMain") {
             dependencies {

--- a/examples/todoapp/common/utils/build.gradle.kts
+++ b/examples/todoapp/common/utils/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-
 plugins {
     id("multiplatform-setup")
     id("android-setup")

--- a/examples/todoapp/gradle.properties
+++ b/examples/todoapp/gradle.properties
@@ -23,5 +23,6 @@ org.gradle.parallel=true
 org.gradle.caching=true
 kotlin.native.disableCompilerDaemon=true
 
+#todo remove -Pkotlin.version=1.6.20 from Xcode project, when stable version on Compose with Koltin 1.6.20 or later released
 kotlin.version=1.6.10
 compose.version=1.1.0

--- a/examples/todoapp/ios/TodoApp.xcodeproj/project.pbxproj
+++ b/examples/todoapp/ios/TodoApp.xcodeproj/project.pbxproj
@@ -29,7 +29,7 @@
 		1F00F390257599DA00CFAF97 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1F00F393257599DA00CFAF97 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		1F00F395257599DA00CFAF97 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		1F00F3A325759FEC00CFAF97 /* Todo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Todo.framework; path = "../common/root/build/xcode-frameworks/Todo.framework"; sourceTree = "<group>"; };
+		1F00F3A325759FEC00CFAF97 /* KotlinCommon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = KotlinCommon.framework; path = "../common/root/build/xcode-frameworks/KotlinCommon.framework"; sourceTree = "<group>"; };
 		1F00F3A72575A16400CFAF97 /* ObservableValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableValue.swift; sourceTree = "<group>"; };
 		1F00F3A92575A71000CFAF97 /* MutableStateBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutableStateBuilder.swift; sourceTree = "<group>"; };
 		1F00F3AB2575AA4500CFAF97 /* ListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListView.swift; sourceTree = "<group>"; };
@@ -101,7 +101,7 @@
 		1F00F3A225759FEC00CFAF97 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				1F00F3A325759FEC00CFAF97 /* Todo.framework */,
+				1F00F3A325759FEC00CFAF97 /* KotlinCommon.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -171,7 +171,7 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
-/* Remove workaround -Pkotlin.version=1.6.20, when newer version of Compose released */
+/* TODO Remove workaround -Pkotlin.version=1.6.20, when newer version of Compose released */
 /* Begin PBXShellScriptBuildPhase section */
 		1F00F39D25759BB300CFAF97 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/examples/todoapp/ios/TodoApp.xcodeproj/project.pbxproj
+++ b/examples/todoapp/ios/TodoApp.xcodeproj/project.pbxproj
@@ -171,6 +171,7 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Remove workaround -Pkotlin.version=1.6.20, when newer version of Compose released */
 /* Begin PBXShellScriptBuildPhase section */
 		1F00F39D25759BB300CFAF97 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -187,7 +188,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd $SRCROOT/..\n./gradlew :common:root:embedAndSignAppleFrameworkForXcode\n";
+			shellScript = "cd $SRCROOT/..\n./gradlew :common:root:embedAndSignAppleFrameworkForXcode -Pkotlin.version=1.6.20\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Set special version of Kotlin to build in Xcode.
val XCODE_WORKAROUND_KOTLIN_VERSION = "1.6.20"

It's temporary workaround and we will remove it, when Compose with newer Kotlin will be available
Can you please test this changes on your Mac?